### PR TITLE
Support small layout for Firefox Overflow Menu

### DIFF
--- a/src/background/create-alias.js
+++ b/src/background/create-alias.js
@@ -20,7 +20,7 @@ async function handleNewRandomAlias(tab) {
         hostname,
       },
       {
-        note: hostname ? `Used on ${hostname}` : '',
+        note: hostname ? `Used on ${hostname}` : "",
       },
       API_ON_ERR.THROW
     );

--- a/src/popup/App-scrollbar.scss
+++ b/src/popup/App-scrollbar.scss
@@ -1,0 +1,18 @@
+.app .content {
+  scrollbar-width: thin;
+}
+
+.content::-webkit-scrollbar-track {
+  background: rgba(0,0,0,0);
+}
+
+.content::-webkit-scrollbar {
+  width: 0.6em;
+}
+
+.content::-webkit-scrollbar-thumb {
+  background: transparent;
+  border: solid 2px transparent;
+  box-shadow: inset 0 0 10px 10px rgba(0, 0, 0, 0.25);
+  border-radius: 16px;
+}

--- a/src/popup/App.scss
+++ b/src/popup/App.scss
@@ -1,4 +1,5 @@
 @import './App-color.scss';
+@import './App-scrollbar.scss';
 @import '~bootstrap/scss/bootstrap.scss';
 @import '~bootstrap-vue/src/index.scss';
 

--- a/src/popup/App.scss
+++ b/src/popup/App.scss
@@ -3,8 +3,6 @@
 @import '~bootstrap-vue/src/index.scss';
 
 body {
-  margin: 0 0;
-  width: 470px;
   box-sizing: content-box !important;
 }
 
@@ -47,6 +45,7 @@ body {
 }
 
 .app {
+  width: 470px;
   box-sizing: content-box !important;
 }
 
@@ -126,20 +125,24 @@ em {
   overflow-y: hidden;
 }
 
-.settings-button {
-  height: 20px;
-  margin-top: 5px;
-  margin-left: 10px;
-  cursor: pointer;
-}
-
-.bug-button {
-  height: 20px;
-  margin-top: 2px;
-  margin-left: 10px;
-  margin-right: 7px;
-  color: #b02a8f;
-  cursor: pointer;
+.header {
+  .settings-button {
+    height: 20px;
+    margin-top: 2px;
+    margin-left: 10px;
+    margin-right: 0px;
+    color: #b02a8f;
+    cursor: pointer;
+  }
+  
+  .bug-button {
+    height: 20px;
+    margin-top: 2px;
+    margin-left: 10px;
+    margin-right: 7px;
+    color: #b02a8f;
+    cursor: pointer;
+  }
 }
 
 .app-header-menu {
@@ -214,4 +217,23 @@ table.settings-list > tr > td {
 
 table.settings-list {
   margin-bottom: 3em;
+}
+
+/* Quick fix for Firefox Overflow Menu */
+.app.ff-overflow-menu {
+  width: auto;
+  max-height: 600px;
+  font-size: 88%;
+
+  textarea, input {
+    font-size: 88%;
+  }
+
+  .header {
+    width: auto;
+
+    .back .sl-logo {
+      display: none;
+    }
+  }
 }

--- a/src/popup/App.scss
+++ b/src/popup/App.scss
@@ -19,11 +19,6 @@ body {
   cursor: pointer;
 }
 
-.content {
-  padding-top: 60px;
-  padding-bottom: 10px;
-}
-
 .overlay {
   position: fixed;
   top: 0;
@@ -47,11 +42,16 @@ body {
 .app {
   width: 470px;
   box-sizing: content-box !important;
+  overflow-y: hidden;
 }
 
 .app .content {
   box-sizing: border-box;
-  margin-bottom: 30px; /* reserved space for toast */
+  margin-top: 45px;
+  padding-top: 15px;
+  padding-bottom: 40px;
+  height: 500px;
+  overflow-y: auto;
 }
 
 .splash .logo {
@@ -126,16 +126,12 @@ em {
 }
 
 .header {
-  .settings-button {
-    height: 20px;
-    margin-top: 2px;
-    margin-left: 10px;
-    margin-right: 0px;
-    color: #b02a8f;
-    cursor: pointer;
+  .actions-container {
+    position: absolute;
+    right: 0.5rem;
   }
   
-  .bug-button {
+  .header-button {
     height: 20px;
     margin-top: 2px;
     margin-left: 10px;
@@ -222,18 +218,25 @@ table.settings-list {
 /* Quick fix for Firefox Overflow Menu */
 .app.ff-overflow-menu {
   width: auto;
-  max-height: 600px;
   font-size: 88%;
+
+  .content {
+    max-height: 500px;
+    overflow-y: auto;
+    scrollbar-width: thin;
+  }
 
   textarea, input {
     font-size: 88%;
   }
 
   .header {
-    width: auto;
+    width: 100%;
 
-    .back .sl-logo {
-      display: none;
+    .dashboard-btn {
+      height: 20px;
+      margin-top: 2px;
+      padding: 0 0.5rem !important;
     }
   }
 }

--- a/src/popup/App.scss
+++ b/src/popup/App.scss
@@ -51,7 +51,7 @@ body {
   margin-top: 45px;
   padding-top: 15px;
   padding-bottom: 40px;
-  height: 500px;
+  max-height: 500px;
   overflow-y: auto;
 }
 

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="app" :class="{ 'ff-overflow-menu': isInsideOverflowMenu }">
     <v-dialog />
-    <sl-header />
+    <sl-header :useCompactLayout="isInsideOverflowMenu" />
     <router-view />
   </div>
 </template>

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="app">
+  <div class="app" :class="{ 'ff-overflow-menu': isInsideOverflowMenu }">
     <v-dialog />
     <sl-header />
     <router-view />
@@ -44,11 +44,28 @@ const router = new VueRouter({
 export default {
   router,
   components,
+  data() {
+    return {
+      isInsideOverflowMenu: false,
+      appScale: 1,
+    };
+  },
   async mounted() {
     await APIService.initService();
     Utils.setToasted(this.$toasted);
     Navigation.setRouter(this.$router);
     Navigation.navigateTo(Navigation.PATH.ROOT);
+    this.detectOverflowMenu();
+  },
+  methods: {
+    detectOverflowMenu() {
+      const appElem = document.querySelector(".app");
+      const appWidth = +getComputedStyle(appElem).width.replace("px", "");
+      const windowWidth = window.innerWidth;
+      if (windowWidth < appWidth) {
+        this.isInsideOverflowMenu = true;
+      }
+    },
   },
 };
 </script>

--- a/src/popup/components/Header.vue
+++ b/src/popup/components/Header.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="header">
-    <!-- TODO: make beta version header compatible with Firefox Overflow Menu -->
-    <div class="row mt-2 pb-2" style="border-bottom: 1px #eee solid;">
-      <div class="col ml-3">
+    <div class="row mt-2 pb-2 ml-3 mr-2" style="border-bottom: 1px #eee solid;">
+      <div>
         <div
           v-on:click="navigateBack()"
           v-bind:class="{ back: canBack }"
@@ -22,22 +21,22 @@
         <div class="beta-badge" v-if="isBeta">BETA</div>
       </div>
 
-      <div v-if="apiKey === ''" class="col mr-2">
-        <button
+      <div v-if="apiKey === ''" class="actions-container">
+        <span
           @click="goToSelfHostSetting"
-          class="btn btn-sm btn-outline-success float-right"
+          class="header-button float-right"
         >
           Settings
-        </button>
+        </span>
       </div>
 
-      <div v-if="apiKey !== ''" class="col mr-2">
+      <div v-if="apiKey !== ''" class="actions-container">
         <span
-          class="settings-button float-right"
+          class="header-button float-right"
           @click="onClickSettingButton"
           v-show="canShowSettingsButton"
           title="Settings"
-          v-b-tooltip.hover
+          v-b-tooltip.hover.bottomleft
         >
           <font-awesome-icon icon="cog" />
         </span>
@@ -45,10 +44,10 @@
         <a
           :href="reportBugUri"
           target="_blank"
-          class="bug-button float-right"
+          class="header-button float-right"
           title="Report an issue"
           v-if="isBeta"
-          v-b-tooltip.hover
+          v-b-tooltip.hover.bottomleft
         >
           <font-awesome-icon icon="bug" />
         </a>
@@ -56,10 +55,14 @@
         <a
           :href="apiUrl + '/dashboard/'"
           target="_blank"
-          class="float-right"
+          class="dashboard-btn float-right"
           style="padding: 0.25rem 0.5rem; font-size: 0.875rem;"
+          title="Dashboard"
+          v-b-tooltip.hover
+          :disabled="!useCompactLayout"
         >
-          Dashboard <font-awesome-icon icon="external-link-alt" />
+          <span v-if="!useCompactLayout">Dashboard</span>
+          <font-awesome-icon icon="external-link-alt" />
         </a>
       </div>
     </div>
@@ -74,6 +77,9 @@ import Utils from "../Utils";
 
 export default {
   name: "sl-header",
+  props: {
+    useCompactLayout: Boolean,
+  },
   data() {
     return {
       apiKey: "",

--- a/src/popup/components/Header.vue
+++ b/src/popup/components/Header.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="header">
+    <!-- TODO: make beta version header compatible with Firefox Overflow Menu -->
     <div class="row mt-2 pb-2" style="border-bottom: 1px #eee solid;">
       <div class="col ml-3">
         <div
@@ -12,7 +13,11 @@
             src="/images/back-button.svg"
             style="height: 20px;"
           />
-          <img src="/images/horizontal-logo.svg" style="height: 18px;" />
+          <img
+            class="sl-logo"
+            src="/images/horizontal-logo.svg"
+            style="height: 18px;"
+          />
         </div>
         <div class="beta-badge" v-if="isBeta">BETA</div>
       </div>
@@ -27,14 +32,15 @@
       </div>
 
       <div v-if="apiKey !== ''" class="col mr-2">
-        <img
-          src="/images/icon-settings.svg"
+        <span
           class="settings-button float-right"
           @click="onClickSettingButton"
           v-show="canShowSettingsButton"
           title="Settings"
           v-b-tooltip.hover
-        />
+        >
+          <font-awesome-icon icon="cog" />
+        </span>
 
         <a
           :href="reportBugUri"

--- a/src/popup/components/Main.vue
+++ b/src/popup/components/Main.vue
@@ -248,6 +248,8 @@ export default {
     this.apiUrl = await SLStorage.get(SLStorage.SETTINGS.API_URL);
     this.apiKey = await SLStorage.get(SLStorage.SETTINGS.API_KEY);
 
+    this.contentElem = document.querySelector('.app > .content');
+
     await this.getUserOptions();
   },
   methods: {
@@ -286,6 +288,7 @@ export default {
     },
 
     async loadAlias() {
+      const contentElem = this.contentElem;
       this.aliasArray = [];
       let currentPage = 0;
 
@@ -294,12 +297,16 @@ export default {
       let allAliasesAreLoaded = false;
 
       let that = this;
-      window.onscroll = async function () {
+      if (this.onScrollCallback) {
+        contentElem.removeEventListener('scroll', this.onScrollCallback);
+      }
+
+      this.onScrollCallback = async function () {
         if (that.isFetchingAlias || allAliasesAreLoaded) return;
 
         let bottomOfWindow =
-          document.documentElement.scrollTop + window.innerHeight >
-          document.documentElement.offsetHeight - 200;
+          contentElem.scrollTop + contentElem.clientHeight  >
+          contentElem.scrollHeight - 100;
 
         if (bottomOfWindow) {
           currentPage += 1;
@@ -313,6 +320,8 @@ export default {
           that.aliasArray = mergeAliases(that.aliasArray, newAliases);
         }
       };
+
+      contentElem.addEventListener('scroll', this.onScrollCallback);
     },
 
     async fetchAlias(page, query) {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -10,7 +10,7 @@
   <!-- Load some resources only in development environment -->
   <% } %>
 </head>
-<body style="overflow-x: hidden;">
+<body style="overflow: hidden;">
   <div id="app"></div>
   <script src="popup.js"></script>
 </body>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -25,6 +25,7 @@ import {
   faSave,
   faBug,
   faQuestionCircle,
+  faCog,
 } from "@fortawesome/free-solid-svg-icons";
 
 library.add(
@@ -37,7 +38,8 @@ library.add(
   faStar,
   faSave,
   faBug,
-  faQuestionCircle
+  faQuestionCircle,
+  faCog
 );
 
 global.browser = require("webextension-polyfill");


### PR DESCRIPTION
Support small layout for Firefox Overflow Menu. Normal layout on Chrome or Firefox (outside overflow menu) remains as before.

![image](https://user-images.githubusercontent.com/7702203/91052626-02e41500-e622-11ea-8505-97bd1a3d9e4e.png)
