### PR TITLE
Context menu "Used on" note

### DIFF
--- a/src/background/context-menu.js
+++ b/src/background/context-menu.js
@@ -66,7 +66,7 @@ function generateAliasHandlerJS(tab, res) {
 }
 
 async function handleOnClickContextMenu(info, tab) {
-  const res = await handleNewRandomAlias(tab);
+  const res = await handleNewRandomAlias(info.pageUrl);
   generateAliasHandlerJS(tab, res);
 }
 


### PR DESCRIPTION
Piggybacking on what @ngxson did in https://github.com/simple-login/browser-extension/commit/0d761cf2c3d3e00d4f896c2abb444aa035305abf regarding the "Used on" note issue #58, this PR fixes a small issue where using the context menu to generate a random email alias would not include a note on what website the alias was "Used on".