### PR TITLE
Keyboard shortcuts and hotkeys

### DIFF
--- a/src/background/context-menu.js
+++ b/src/background/context-menu.js
@@ -70,4 +70,4 @@ async function handleOnClickContextMenu(info, tab) {
   generateAliasHandlerJS(tab, res);
 }
 
-export { handleOnClickContextMenu };
+export { handleOnClickContextMenu, generateAliasHandlerJS };

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -2,6 +2,7 @@ import browser from "webextension-polyfill";
 import APIService from "../popup/APIService";
 import SLStorage from "../popup/SLStorage";
 import Onboarding from "./onboarding";
+import Utils from "../popup/Utils"
 import "./content-script";
 
 import { handleNewRandomAlias } from "./create-alias";
@@ -44,6 +45,17 @@ browser.contextMenus.create({
   title: "Create random email alias (copied)",
   contexts: ["all"],
   onclick: handleOnClickContextMenu,
+});
+
+/**
+ * Shortcuts and hotkeys listener
+ */
+browser.commands.onCommand.addListener(async (command)  => {
+  if (command === "generate-random-alias") {
+	console.log("generate-random-alias");
+	const currentTab = (await browser.tabs.query({active: true, currentWindow: true}))[0];
+	return await handleNewRandomAlias(currentTab.url);
+  }
 });
 
 APIService.initService();

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -5,7 +5,10 @@ import Onboarding from "./onboarding";
 import "./content-script";
 
 import { handleNewRandomAlias } from "./create-alias";
-import { handleOnClickContextMenu, generateAliasHandlerJS } from "./context-menu";
+import {
+  handleOnClickContextMenu,
+  generateAliasHandlerJS,
+} from "./context-menu";
 import { firePermissionListener } from "./permissions";
 
 global.isBackgroundJS = true;
@@ -49,11 +52,13 @@ browser.contextMenus.create({
 /**
  * Shortcuts and hotkeys listener
  */
-browser.commands.onCommand.addListener(async (command)  => {
+browser.commands.onCommand.addListener(async (command) => {
   if (command === "generate-random-alias") {
-	const currentTab = (await browser.tabs.query({active: true, currentWindow: true}))[0];
-	const res = await handleNewRandomAlias(currentTab.url);
-	generateAliasHandlerJS(currentTab, res);
+    const currentTab = (
+      await browser.tabs.query({ active: true, currentWindow: true })
+    )[0];
+    const res = await handleNewRandomAlias(currentTab.url);
+    generateAliasHandlerJS(currentTab, res);
   }
 });
 

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -2,11 +2,10 @@ import browser from "webextension-polyfill";
 import APIService from "../popup/APIService";
 import SLStorage from "../popup/SLStorage";
 import Onboarding from "./onboarding";
-import Utils from "../popup/Utils"
 import "./content-script";
 
 import { handleNewRandomAlias } from "./create-alias";
-import { handleOnClickContextMenu } from "./context-menu";
+import { handleOnClickContextMenu, generateAliasHandlerJS } from "./context-menu";
 import { firePermissionListener } from "./permissions";
 
 global.isBackgroundJS = true;
@@ -52,9 +51,9 @@ browser.contextMenus.create({
  */
 browser.commands.onCommand.addListener(async (command)  => {
   if (command === "generate-random-alias") {
-	console.log("generate-random-alias");
 	const currentTab = (await browser.tabs.query({active: true, currentWindow: true}))[0];
-	return await handleNewRandomAlias(currentTab.url);
+	const res = await handleNewRandomAlias(currentTab.url);
+	generateAliasHandlerJS(currentTab, res);
   }
 });
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,10 +41,10 @@
 	  "description": "Generate a random email alias"
 	},
 	"_execute_browser_action": {
-		"suggested_key": {
-		  "default": "Ctrl+Alt+S"
-		},
-		"description":"Open the extension action menu"
+	  "suggested_key": {
+		"default": "Ctrl+Alt+S"
+	  },
+	  "description":"Open the extension action menu"
 	}
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -37,13 +37,13 @@
   "commands": {
 	"generate-random-alias": {
 	  "suggested_key": {
-		"default": "Ctrl+Alt+X"
+		"default": "Ctrl+Shift+X"
 	  },
 	  "description": "Generate a random email alias"
 	},
 	"_execute_browser_action": {
 	  "suggested_key": {
-		"default": "Ctrl+Alt+S"
+		"default": "Ctrl+Shift+S"
 	  },
 	  "description":"Open the extension action menu"
 	}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -32,5 +32,19 @@
     "scripts": [
       "background.js"
     ]
+  },
+  "commands": {
+	"generate-random-alias": {
+	  "suggested_key": {
+		"default": "Ctrl+Alt+X"
+	  },
+	  "description": "Generate a random email alias"
+	},
+	"_execute_browser_action": {
+		"suggested_key": {
+		  "default": "Ctrl+Alt+S"
+		},
+		"description":"Open the extension action menu"
+	}
   }
 }


### PR DESCRIPTION
This PR adds support for hotkeys and keyboard shortcuts (as requested on Trello) to:
- open the extension menu (action menu) using **Ctrl+Alt+S** 
- generate a random email alias (which is copied to clipboard) using **Ctrl+Alt+X**
Other hotkeys can be added later as these may serve as an example.

These hotkeys can be edited using the browser's add-ons shortcuts settings:

![image](https://user-images.githubusercontent.com/2602462/92435383-777e8e00-f1a2-11ea-855d-58b995a08707.png)

Note: I have tested these changes on Firefox 80, can someone confirm that they work on other browsers too ?
