### PR TITLE
Store API data in local storage instead of sync storage.

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -62,5 +62,7 @@ browser.commands.onCommand.addListener(async (command) => {
   }
 });
 
+SLStorage.convertFromSyncToLocal(SLStorage.SETTINGS.API_URL);
+SLStorage.convertFromSyncToLocal(SLStorage.SETTINGS.API_KEY);
 APIService.initService();
 Onboarding.initService();

--- a/src/popup/SLStorage.js
+++ b/src/popup/SLStorage.js
@@ -12,6 +12,14 @@ class SLStorage {
     SL_BUTTON_POSITION: "SLButtonPosition",
   };
 
+  static TYPES = {
+    apiUrl: "local",
+    apiKey: "local",
+    notAskingRate: "sync",
+    showSLButton: "sync",
+    SLButtonPosition: "sync"
+  }
+
   static DEFAULT_SETTINGS = {
     [SLStorage.SETTINGS.API_URL]: devConfig
       ? devConfig.DEFAULT_API_URL
@@ -23,11 +31,13 @@ class SLStorage {
   };
 
   static set(key, value) {
-    return browser.storage.sync.set({ [key]: value });
+    const type = this.TYPES[key];
+    return browser.storage[type].set({ [key]: value });
   }
 
   static async get(key) {
-    const data = await browser.storage.sync.get(key);
+    const type = this.TYPES[key];
+    const data = await browser.storage[type].get(key);
 
     if (data[key] === undefined || data[key] === null) {
       return SLStorage.DEFAULT_SETTINGS[key] || "";
@@ -37,10 +47,12 @@ class SLStorage {
   }
 
   static remove(key) {
-    return browser.storage.sync.remove(key);
+    const type = this.TYPES[key];
+    return browser.storage[type].remove(key);
   }
 
-  static clear() {
+  static async clear() {
+    await browser.storage.local.clear();
     return browser.storage.sync.clear();
   }
 
@@ -50,6 +62,13 @@ class SLStorage {
 
   static getTemporary(key) {
     return TEMP[key];
+  }
+
+  static async convertFromSyncToLocal(key) {
+    const data = await browser.storage.sync.get(key);
+    if (data[key]) {
+      await browser.storage.local.set({ [key]: data[key] }).then(_ => browser.storage.sync.remove(key));
+    }
   }
 }
 


### PR DESCRIPTION
Closes #121

Stores `apiUrl` and `apiKey` in local storage instead of sync storage. We use a separate `TYPES` variable for this instead of making `SETTINGS` an object for ease of use when using `SETTINGS` keys.
On startup, moves any existing `apiUrl` or `apiKey` values in sync storage to local storage and deletes them from sync storage if successful.