### PR TITLE
Allow to query if extension is installed

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -89,6 +89,20 @@ const isMessageAllowed = (url) => {
 };
 
 /**
+ * Handle the event of a page querying if the SL extension is installed
+ * @return {{data: {version: string}, tag: string}}
+ */
+const handleExtensionInstalledQuery = () => {
+  const manifest = browser.runtime.getManifest();
+  return {
+    tag: "EXTENSION_INSTALLED_RESPONSE",
+    data: {
+      version: manifest.version,
+    },
+  };
+};
+
+/**
  * Register onMessage listener
  */
 browser.runtime.onMessage.addListener(async function (request, sender) {
@@ -104,6 +118,8 @@ browser.runtime.onMessage.addListener(async function (request, sender) {
 
   if (request.tag === "EXTENSION_SETUP") {
     return await handleExtensionSetup();
+  } else if (request.tag === "EXTENSION_INSTALLED_QUERY") {
+    return handleExtensionInstalledQuery();
   }
 });
 

--- a/src/content_script/input_tools.js
+++ b/src/content_script/input_tools.js
@@ -245,6 +245,8 @@ if (!window._hasExecutedSlExtension) {
     if (!window.hasSlListenerRegistered) {
       window.hasSlListenerRegistered = true;
 
+      let hasProcessedSetup = false;
+
       /**
        * Callback called for every event
        * @param {MessageEvent<any>} event
@@ -253,7 +255,15 @@ if (!window._hasExecutedSlExtension) {
         if (event.source !== window) return;
         if (!event.data.tag) return;
         if (event.data.tag === "PERFORM_EXTENSION_SETUP") {
-          await sendMessageToBackground("EXTENSION_SETUP");
+          if (!hasProcessedSetup) {
+            hasProcessedSetup = true;
+            await sendMessageToBackground("EXTENSION_SETUP");
+          }
+        } else if (event.data.tag === "EXTENSION_INSTALLED_QUERY") {
+          const res = await sendMessageToBackground(
+            "EXTENSION_INSTALLED_QUERY"
+          );
+          window.postMessage(res);
         }
       };
 


### PR DESCRIPTION
This PR performs the following changes:

1. Adds a method that allows the browser to query if the extension is installed. In case it's installed it can access the extension version.
2. Adds a check so the extension only processes the setup once per page.