### PR TITLE
Provide correct ASSET_PATH and ASSET_NAME

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,8 +126,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ env.RELEASE_UPLOAD_URL }}
-          asset_path: ${{ env.ASSET }}
-          asset_name: ${{ env.ASSET }}
+          asset_path: ${{ env.ASSET_PATH }}
+          asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: application/octet-stream
 
       - name: Post notification to Slack


### PR DESCRIPTION
This PR fixes the usage of `env.ASSET_NAME` and `env.ASSET_PATH` for uploading the artifacts to the GitHub release