### PR TITLE
Fix slack message

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
           messageWithoutDoubleQuotes=$(echo "${messageWithoutNewlines}" | sed "s/\"/'/g")
           echo "${messageWithoutDoubleQuotes}"
           
-          echo "SLACK_CHANGELOG=${messageWithoutDoubleQuotes}" > artifacts/slack-changelog
+          echo "${messageWithoutDoubleQuotes}" > artifacts/slack-changelog
 
       - name: Create GitHub release
         id: release


### PR DESCRIPTION
The `SLACK_CHANGELOG=` prefix should not be added to the changelog, as the contents are read directly on a later stage