### PR TITLE
Remove tabs permission

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -15,7 +15,6 @@
     "activeTab",
     "storage",
     "contextMenus",
-    "tabs",
     "https://*.simplelogin.io/*",
     "http://*/*",
     "https://*/*"


### PR DESCRIPTION
This PR removes the `tabs` permission, as apparently we can do the same work requesting just the `activeTab` permission.