### PR TITLE
fix the "create totally random alias" button includes hostname in alias

### DIFF
--- a/src/popup/components/Main.vue
+++ b/src/popup/components/Main.vue
@@ -428,7 +428,7 @@ export default {
         const res = await callAPI(
           API_ROUTE.NEW_RANDOM_ALIAS,
           {
-            hostname: this.hostName,
+            hostname: "",
           },
           {
             note: await Utils.getDefaultNote(),


### PR DESCRIPTION
Currently when clicking on "create totally random alias" button, the hostname is automatically included in the alias address which is a bug. This PR fixes that.