### PR TITLE
Release lite extension from actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,11 @@ jobs:
     name: build-release
     needs: ['create-release']
     runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        variant: ['full', 'lite']
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -104,16 +109,25 @@ jobs:
           release_version="$(cat artifacts/release-version)"
           echo "RELEASE_VERSION=$release_version" >> $GITHUB_ENV
           echo "release version: $RELEASE_VERSION"
-          
-          # Set the slack-changelog
-          slack_changelog=$(cat artifacts/slack-changelog)
-          echo "SLACK_CHANGELOG=$slack_changelog" >> $GITHUB_ENV
-          echo "slack changelog: $SLACK_CHANGELOG"
 
-      - name: Build extension
+      - name: Build lite version
+        if: ${{ matrix.variant }} == 'lite'
+        shell: bash
         run: |
           npm install
-          npm run build && npm run build-zip
+          npm run build:lite
+          SUFFIX=lite npm run build-zip
+
+      - name: Build full version
+        if: ${{ matrix.variant }} == 'full'
+        shell: bash
+        run: |
+          npm install
+          npm run build
+          npm run build-zip
+
+      - name: Package extension
+        run: |
           ZIP_NAME=$(find dist-zip -type f -name '*.zip' | head -n 1)
           ASSET_NAME=$(basename "${ZIP_NAME}")
           
@@ -129,6 +143,25 @@ jobs:
           asset_path: ${{ env.ASSET_PATH }}
           asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: application/octet-stream
+
+  notify:
+    name: notify
+    needs: ['create-release', 'build-release']
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: artifacts
+          path: artifacts
+
+      - name: Read artifacts
+        shell: bash
+        run: |
+          # Set the slack-changelog
+          slack_changelog=$(cat artifacts/slack-changelog)
+          echo "SLACK_CHANGELOG=$slack_changelog" >> $GITHUB_ENV
+          echo "slack changelog: $SLACK_CHANGELOG"
 
       - name: Post notification to Slack
         uses: slackapi/slack-github-action@v1.19.0

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prettier:write": "npm run prettier -- --write",
     "prettier:check": "prettier --check \"src/**/*.{js,vue}\"",
     "build": "cross-env NODE_ENV=production webpack",
+    "build:lite": "cross-env NODE_ENV=production LITE=1 webpack",
     "build:beta": "cross-env NODE_ENV=production BETA=1 webpack",
     "build:dev": "cross-env NODE_ENV=development BETA=1 webpack",
     "build-zip": "node scripts/build-zip.js",

--- a/scripts/build-zip.js
+++ b/scripts/build-zip.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const process = require('process');
 const fs = require('fs');
 const path = require('path');
 const archiver = require('archiver');
@@ -42,9 +43,17 @@ const buildZip = (src, dist, zipFilename) => {
   });
 };
 
+const extractSuffix = () => {
+  if (process.env.SUFFIX) {
+    return `-${process.env.SUFFIX}`;
+  }
+  return '';
+};
+
 const main = () => {
   const {name, version} = extractExtensionData();
-  const zipFilename = `${name}-v${version}.zip`;
+  const suffix = extractSuffix();
+  const zipFilename = `${name}${suffix}-v${version}.zip`;
   
   makeDestZipDirIfNotExists();
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,7 +44,7 @@
       "suggested_key": {
         "default": "Ctrl+Shift+S"
       },
-      "description":"Open the extension action menu"
+      "description": "Open the extension action menu"
     }
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,6 +118,26 @@ const config = {
               jsonContent.browser_specific_settings.gecko.id = geckoId.replace('@', '-beta@');
             }
 
+            if (process.env.LITE) {
+              // Remove "All sites" permissions
+              const PERMISSIONS_TO_REMOVE = [
+                "https://*/*",
+                "http://*/*"
+              ];
+
+              const finalPermissions = [];
+              for (const perm of jsonContent.permissions) {
+                if (!PERMISSIONS_TO_REMOVE.includes(perm)) {
+                  finalPermissions.push(perm);
+                }
+              }
+              jsonContent.permissions = finalPermissions;
+
+              // Change metadata
+              jsonContent.name = "SimpleLogin Without SL icon";
+              jsonContent.short_name = "SimpleLogin Without SL icon";
+            }
+
             return JSON.stringify(jsonContent, null, 2);
           },
         },


### PR DESCRIPTION
This PR adds the following changes:

1. Add a `build:lite` command for building the "lite" variant of the extension (the one that does not include the SL button by not adding the "all" permissions).
2. Adapt the `build-zip` script for being able to receive a suffix.
3. Make actions create both variants.