### PR TITLE
Enable Login with Proton

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,7 +113,7 @@ jobs:
       - name: Generate buildConfig
         shell: bash
         env:
-          ENABLE_LOGIN_WITH_PROTON: false
+          ENABLE_LOGIN_WITH_PROTON: true
         run: |
           npm run generate:buildconfig
 

--- a/scripts/generateBuildConfig.js
+++ b/scripts/generateBuildConfig.js
@@ -3,9 +3,17 @@ const path = require('path');
 
 const PATH = path.join(__dirname, '../src', 'popup', 'buildConfig.json');
 
+const isLoginWithProtonEnabled = () => {
+    const enableLoginWithProton = process.env.ENABLE_LOGIN_WITH_PROTON;
+    if (enableLoginWithProton == undefined || enableLoginWithProton === 'true') {
+        return true;
+    }
+    return false;
+};
+
 const config = {
   features: {
-    loginWithProtonEnabled: process.env.ENABLE_LOGIN_WITH_PROTON === 'true'
+    loginWithProtonEnabled: isLoginWithProtonEnabled()
   },
   buildTime: new Date().getTime()
 };


### PR DESCRIPTION
This PR performs the following changes:

1. Makes the extension release process to have the "Login with Proton" enabled.
2. Makes the "Login with Proton" option enabled by default, unless the builder explicitly sets the `ENABLE_LOGIN_WITH_PROTON` variable to something other than `true`