### PR TITLE
Fix Theme.js case sensitive

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,8 +78,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-#        variant: ['full', 'lite']
-        variant: ['full']
+        variant: ['full', 'lite']
 
     steps:
       - name: Build info

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplelogin-extension",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "simplelogin-extension",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.36",

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -23,7 +23,7 @@ import AppSettings from "./components/AppSettings";
 import SLStorage from "./SLStorage";
 import Utils from "./Utils";
 import APIService from "./APIService";
-import { getSavedTheme, setThemeClass } from "./theme";
+import { getSavedTheme, setThemeClass } from "./Theme";
 
 const components = {
   "sl-header": Header,

--- a/src/popup/SLStorage.js
+++ b/src/popup/SLStorage.js
@@ -1,6 +1,6 @@
 import Utils from "./Utils";
 import browser from "webextension-polyfill";
-import { THEME_SYSTEM } from "./theme";
+import { THEME_SYSTEM } from "./Theme";
 
 const TEMP = {};
 

--- a/src/popup/components/AppSettings.vue
+++ b/src/popup/components/AppSettings.vue
@@ -103,7 +103,7 @@ import EventManager from "../EventManager";
 import Navigation from "../Navigation";
 import Utils from "../Utils";
 import { callAPI, API_ROUTE, API_ON_ERR } from "../APIService";
-import { setThemeClass, THEME_LABELS, THEMES, getSavedTheme } from "../theme";
+import { setThemeClass, THEME_LABELS, THEMES, getSavedTheme } from "../Theme";
 
 export default {
   data() {


### PR DESCRIPTION
This PR performs the following changes:

1. Fixes the imports of the `Theme.js` which were written as `theme`. In case insensitive FS (such as the macOS one) it would work, but on case sensitive filesystems it wouldn't.
2. Updates the version in the `package-lock.json` file so it matches the `package.json` one.
3. Re-enables building the `lite` variant.