### PR TITLE
(chore) add suffix when building mac app

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,7 +142,7 @@ jobs:
         run: |
           npm install
           npm run build:mac
-          npm run build-zip
+          SUFFIX=mac npm run build-zip
 
       - name: Package extension
         run: |


### PR DESCRIPTION
This PR adds a change that will add a `-mac` suffix when building the mac app on CI.

This is necessary, as the `build-release (full)` and `build-release (mac)` generated an artifact with the same name, which could not be uploaded to the release.