### PR TITLE
Check for empty event data messages

### DIFF
--- a/src/content_script/input_tools.js
+++ b/src/content_script/input_tools.js
@@ -253,6 +253,7 @@ if (!window._hasExecutedSlExtension) {
        */
       const onEvent = async (event) => {
         if (event.source !== window) return;
+        if (!event.data) return;
         if (!event.data.tag) return;
         if (event.data.tag === "PERFORM_EXTENSION_SETUP") {
           if (!hasProcessedSetup) {


### PR DESCRIPTION
This MR adds a check that prevents the code from accessing `event.data.tag` if `event.data` is `null`