### PR TITLE
Fix "sl-button" CSS class name conflicting with certain websites

### DIFF
--- a/src/content_script/input_tools.css
+++ b/src/content_script/input_tools.css
@@ -1,9 +1,9 @@
-.sl-button-wrapper {
+.simplelogin-extension--button-wrapper {
   position: absolute;
   z-index: 999999;
 }
 
-.sl-button {
+.simplelogin-extension--button {
   cursor: pointer;
   box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.3);
   max-height: 30px;
@@ -22,14 +22,14 @@
   background-size: contain;
 }
 
-.sl-button:hover {
+.simplelogin-extension--button:hover {
   transform: translate(-50%, -50%) scale(1.2);
 }
 
-.sl-button.loading {
+.simplelogin-extension--button.loading {
   background-image: url("data:image/svg+xml,%3C%3Fxml version='1.0' encoding='utf-8'%3F%3E%3Csvg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' style='margin: auto; background: none; display: block; shape-rendering: auto;' width='200px' height='200px' viewBox='0 0 100 100' preserveAspectRatio='xMidYMid'%3E%3Ccircle cx='50' cy='50' fill='none' stroke='%23aa2990' stroke-width='10' r='35' stroke-dasharray='164.93361431346415 56.97787143782138' transform='rotate(178.465 50 50)'%3E%3CanimateTransform attributeName='transform' type='rotate' repeatCount='indefinite' dur='1s' values='0 50 50;360 50 50' keyTimes='0;1'%3E%3C/animateTransform%3E%3C/circle%3E%3C/svg%3E");
 }
 
-.sl-button.loading:hover {
+.simplelogin-extension--button.loading:hover {
   transform: translate(-50%, -50%);
 }

--- a/src/content_script/input_tools.js
+++ b/src/content_script/input_tools.js
@@ -89,7 +89,7 @@ if (!window._hasExecutedSlExtension) {
 
         addSLButtonToInput(inputElem) {
           // create wrapper for SL button
-          const btnWrapper = InputTools.newDiv("sl-button-wrapper");
+          const btnWrapper = InputTools.newDiv("simplelogin-extension--button-wrapper");
           const inputSumHeight =
             inputElem.getBoundingClientRect().height + "px";
           btnWrapper.style.height = inputSumHeight;
@@ -97,7 +97,7 @@ if (!window._hasExecutedSlExtension) {
           document.body.appendChild(btnWrapper);
 
           // create the SL button
-          const slButton = InputTools.newDiv("sl-button");
+          const slButton = InputTools.newDiv("simplelogin-extension--button");
           slButton.addEventListener("click", function () {
             InputTools.handleOnClickSLButton(inputElem, slButton);
           });

--- a/src/content_script/input_tools.js
+++ b/src/content_script/input_tools.js
@@ -88,8 +88,11 @@ if (!window._hasExecutedSlExtension) {
         },
 
         addSLButtonToInput(inputElem) {
+          const CSS_CLASS_PREFIX = "simplelogin-extension--";
+          const prefixClassName = (classname) => `${CSS_CLASS_PREFIX}${classname}`;
+
           // create wrapper for SL button
-          const btnWrapper = InputTools.newDiv("simplelogin-extension--button-wrapper");
+          const btnWrapper = InputTools.newDiv(prefixClassName("button-wrapper"));
           const inputSumHeight =
             inputElem.getBoundingClientRect().height + "px";
           btnWrapper.style.height = inputSumHeight;
@@ -97,7 +100,7 @@ if (!window._hasExecutedSlExtension) {
           document.body.appendChild(btnWrapper);
 
           // create the SL button
-          const slButton = InputTools.newDiv("simplelogin-extension--button");
+          const slButton = InputTools.newDiv(prefixClassName("button"));
           slButton.addEventListener("click", function () {
             InputTools.handleOnClickSLButton(inputElem, slButton);
           });

--- a/src/content_script/input_tools.js
+++ b/src/content_script/input_tools.js
@@ -88,11 +88,8 @@ if (!window._hasExecutedSlExtension) {
         },
 
         addSLButtonToInput(inputElem) {
-          const CSS_CLASS_PREFIX = "simplelogin-extension--";
-          const prefixClassName = (classname) => `${CSS_CLASS_PREFIX}${classname}`;
-
           // create wrapper for SL button
-          const btnWrapper = InputTools.newDiv(prefixClassName("button-wrapper"));
+          const btnWrapper = InputTools.newDiv("simplelogin-extension--button-wrapper");
           const inputSumHeight =
             inputElem.getBoundingClientRect().height + "px";
           btnWrapper.style.height = inputSumHeight;
@@ -100,7 +97,7 @@ if (!window._hasExecutedSlExtension) {
           document.body.appendChild(btnWrapper);
 
           // create the SL button
-          const slButton = InputTools.newDiv(prefixClassName("button"));
+          const slButton = InputTools.newDiv("simplelogin-extension--button");
           slButton.addEventListener("click", function () {
             InputTools.handleOnClickSLButton(inputElem, slButton);
           });


### PR DESCRIPTION
The CSS used by the SimpleLogin button in email input fields could create a conflict with the CSS on certain websites using the same CSS class names. I gave unique class names for the SimpleLogin button.