### PR TITLE
Include X-Sl-Allowcookies headers for onboarding 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplelogin-extension",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "betaRev": "0",
   "description": "SimpleLogin Browser Extension",
   "author": "extension@simplelogin.io",

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -33,6 +33,7 @@ async function handleExtensionSetup() {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      "X-Sl-Allowcookies": true,
     },
     body: JSON.stringify({
       device: Utils.getDeviceName(),

--- a/src/popup/components/SplashScreen.vue
+++ b/src/popup/components/SplashScreen.vue
@@ -42,6 +42,9 @@ export default {
         method: "POST",
         body: JSON.stringify({
           device: Utils.getDeviceName(),
+        },
+        headers: {
+          "X-Sl-Allowcookies": true,
         }),
       });
 

--- a/src/popup/components/SplashScreen.vue
+++ b/src/popup/components/SplashScreen.vue
@@ -42,10 +42,10 @@ export default {
         method: "POST",
         body: JSON.stringify({
           device: Utils.getDeviceName(),
-        },
+        }),
         headers: {
           "X-Sl-Allowcookies": true,
-        }),
+        },
       });
 
       if (res.ok) {


### PR DESCRIPTION
After https://github.com/simple-login/app/commit/5d48b5878fb74c66d9657b1b24a78fa02da3f020 automatic onboarding will fail due to the missing X-Sl-Allowcookies header. Updated requests to /api/api_key to include the new header