### PR TITLE
fix: use prototypes and event dispatchers for updating email input values

### DIFF
--- a/src/content_script/input_tools.js
+++ b/src/content_script/input_tools.js
@@ -174,6 +174,10 @@ if (!window._hasExecutedSlExtension) {
           );
           const valueSetter = descriptor ? descriptor.set : null;
 
+          // More on why we're dispatching an event at the end of the function definition.
+          const focusEvent = new Event("focus", { bubbles: true });
+          input.dispatchEvent(focusEvent);
+
           if (valueSetter) {
             valueSetter.call(input, value);
           } else {
@@ -181,13 +185,19 @@ if (!window._hasExecutedSlExtension) {
             input.value = value;
           }
 
-          // Dispatch a bubbling 'input' event to trigger React's event system.
-          // Also can help other frameworks, or even Vanilla JS to register
-          // other event handlers, such as 'onchange' and/or 'oninput'.
-          // They might help to get an intended behaviour out of an input, such
-          // as input validation, etc.
-          const event = new Event("input", { bubbles: true });
-          input.dispatchEvent(event);
+          // Define and dispatch a bubbling 'input' event to trigger React's event system.
+          const inputEvent = new Event("input", { bubbles: true });
+          input.dispatchEvent(inputEvent);
+          // 'input' and 'change' events are interchangable to React's event system when \
+          // it comes to updating the value. Since we're already dispatching an event, we \
+          // might as well trigger 'change' for any other case when events are handled by \
+          // a standard DOM (i.e Vanilla JS/other frameworks) and have different functionality.
+          const changeEvent = new Event("change", { bubbles: true });
+          input.dispatchEvent(changeEvent);
+          // We can also dispatch 'blur' event to emulate natural user behaviour and intended UX.
+          // Simply changing the input.value doesn't trigget any events.
+          const blurEvent = new Event("blur", { bubbles: true });
+          input.dispatchEvent(blurEvent);
         },
 
         async handleOnClickSLButton(inputElem, slButton) {

--- a/src/content_script/input_tools.js
+++ b/src/content_script/input_tools.js
@@ -174,9 +174,9 @@ if (!window._hasExecutedSlExtension) {
           );
           const valueSetter = descriptor ? descriptor.set : null;
 
-          // More on why we're dispatching an event at the end of the function definition.
-          const focusEvent = new Event("focus", { bubbles: true });
-          input.dispatchEvent(focusEvent);
+          // Focus the input to ensure frameworks that rely on real focus state
+          // (e.g. React-Hook-Form's touched) pick up on the change.
+          input.focus();
 
           if (valueSetter) {
             valueSetter.call(input, value);
@@ -185,7 +185,7 @@ if (!window._hasExecutedSlExtension) {
             input.value = value;
           }
 
-          // Define and dispatch a bubbling 'input' event to trigger React's event system.
+          // Dispatch bubbling 'input' event to trigger React's event system.
           const inputEvent = new Event("input", { bubbles: true });
           input.dispatchEvent(inputEvent);
           // 'input' and 'change' events are interchangable to React's event system when \
@@ -194,10 +194,8 @@ if (!window._hasExecutedSlExtension) {
           // a standard DOM (i.e Vanilla JS/other frameworks) and have different functionality.
           const changeEvent = new Event("change", { bubbles: true });
           input.dispatchEvent(changeEvent);
-          // We can also dispatch 'blur' event to emulate natural user behaviour and intended UX.
-          // Simply changing the input.value doesn't trigget any events.
-          const blurEvent = new Event("blur", { bubbles: true });
-          input.dispatchEvent(blurEvent);
+          // Blur the input to trigger validation that keys on blur state (e.g. touched).
+          input.blur();
         },
 
         async handleOnClickSLButton(inputElem, slButton) {


### PR DESCRIPTION
## General Information

### What is this PR about?
This is my attempt at implementing a bit more robust method for input updates.
More specifically, it uses the `input` event dispatchers and prototypes to handle the intricacies of how React works.

### Why did make it?
While using the extension, I have noticed that on some websites, email generation and autofill on inputs would generate an alias, but with any further interaction with the input, the alias would disappear. I immediately knew that the culprit was the JS framework React, specifically the virtual DOM. I decided to fix it myself, since most of the modern web runs some kind of React derivative. This would make using the button pointless, as you would need to click on the extension in your address bar anyway to copy the alias.  
After checking the repo for similar reports, I was surprised to find that there was no mention of this issue, so I have decided to fix it myself and contribute back to make the extension more usable for everyone.
<h3>
<details><summary>Demonstration of an issue (open to see the gif):</summary>
<p>

![sl-ext-unpatched-unoptimized](https://github.com/user-attachments/assets/794fd07d-afe8-446b-9982-fff4d43e221f)

</p>
</details>
</h3>

### How does it work?
React uses a synthetic event system and attaches its own getters and setters to DOM elements to manage their state and updates. Simply changing the `value` property of an input element doesn't inform React of the change because React doesn't listen to native DOM events directly.  
While one solution would be to somehow use React's internal setters, this approach would be cumbersome to implement correctly and may vary from version to version of the framework.  
A cleaner and more universal solution is to use the original setter of an input element prototype and then dispatch an `input` event. This would trigger React's event system and let it pick up the updated value in its virtual DOM.

### Does that mean we need to have special handling for React?
Not really! The good thing about this method is that it's pretty much universal, as every functional website that's running JavaScript would have its setters on the element prototypes. This means that we don't need to check if the website is running React or not, since the prototypes are a core part of DOM APIs. In some rare edge cases where the prototype is not available, we can still fall back to just updating the `value` property and hoping for the best.

### But wouldn't that add more overhead to maintaining the code?
Technically speaking, yes, but I have abstracted the input update mechanism behind a function, so it just takes an element and a new value. I have also added a bunch of inline comments to provide context about what each part of the function does and why. From a performance standpoint, we're basically already doing what straightforward value updating would do but breaking it down into steps.

## Testing

### Build:
- [x] Production build is successful
- [x] Linting is successful

### Tested on:
- [x] Firefox v133.0.3 — working as expected
- [x] Google Chrome v132.0 — working as expected

### Verified that:
- [x] New input update mechanism works as expected on:
	- [x] Next.js (React-based) website - [Link](https://mynixos.com/signup)
	- [x] Angular website - [Link](https://www.spirit.com/retrieve-password)
	- [x] Vue.js website - [Link](https://habitica.com/static/home)
	- [x] Framework-less website - [Link](https://order.anydesk.com/trial)

<h3>
<details><summary>Fix in action (open to see the gif):</summary>
<p>

![sl-ext-patched-unoptimized](https://github.com/user-attachments/assets/68680c67-7029-4c94-a6d0-2bd6760fb273)

</p>
</details> 
</h3>

## P.S.
I have also taken the liberty of dispatching a few additional events, mainly to mimic the actions a user would take to improve UX. For example, we will dispatch a `change` event alongside `input`, just in case some websites use a different listener. Additionally, dispatching `focus`/`blur` events should hopefully trigger some QoL features, like input validation and email availability. I did encounter a couple of annoyances while using the extension myself and testing this PR, such as not validating the email until you click the input again to bring it in/out of focus, only to receive a message that the service is not accepting the alias's domain.
### P.P.S.
I hope it wasn't very painful to read this wall of text! 😅

I was initially thinking of creating an issue and putting these explanations there and just linking the PR to it. But it seemed a bit pointless since issues are meant to discuss the problem, and I have already fixed it myself.  
Contributing to OSS is still new for me, and while I have tried to research as much as possible about the development style of this repo, I hope I didn't make any terrible mistakes. If I did, please let me know so that we can discuss them, and I will try to fix them! I'm eager to learn and open to any feedback or suggestions.

Thank you for considering this pull request!